### PR TITLE
Adding Ensemble z sweep module

### DIFF
--- a/2.ensemble-z-analysis/README.md
+++ b/2.ensemble-z-analysis/README.md
@@ -1,0 +1,35 @@
+# Ensemble Z Analysis
+
+**Gregory Way, 2018**
+
+Gene expression data compression reveals coordinated gene expression modules that describe important biology.
+In the following analysis, we apply a series of compression algorithms to gene expression datasets.
+Through each series, we alter the dimensionality (z) of the bottleneck and compare mathematical performance.
+We also save the population of all models, for each algorithm, across z for downstream analyses.
+
+## Algorithms
+
+We compress gene expression data with the following algorithms:
+
+| Algorithm | Implementation |
+| :-------: | :------------: |
+| Principal Components Analysis (PCA) | [sklearn](http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) |
+| Independent Components Analysis (ICA) | [sklearn](http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.FastICA.html) |
+| Non-Negative Matrix Factorization (NMF) | [sklearn](http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html) |
+| Analysis of Denoising Autoencoders for Gene Expression (ADAGE) | [tybalt.models.Adage](https://github.com/greenelab/tybalt/blob/master/tybalt/models.py#L284)
+| Variational Autoencoder (VAE; Tybalt) | [tybalt.models.Tybalt](https://github.com/greenelab/tybalt/blob/master/tybalt/models.py#L25)
+
+## Evaluation Metrics
+
+We will evaluate the solutions across the ensemble population over all z dimensions.
+
+1. Reconstruction Cost - Measures the binary cross entropy of input data to reconstruction
+2. Training History - For neural network models (ADAGE, Tybalt), save the training progress of each model
+  * For Tybalt, the KL Divergence and Reconstruction Loss are saved separately
+3. Correlation of input sample to reconstructed sample - Measure how well certain samples traverse through the bottleneck.
+  * Calculate Pearson and Spearman correlations
+  * May reveal certain biases in sample reconstruction efficiency across algorithms
+
+The population of weight and z matrices are also saved for alternative downstream analyses.
+These analyses include automatic interpretation of compressed features with HetMech.
+

--- a/2.ensemble-z-analysis/scripts/train_models_given_z.py
+++ b/2.ensemble-z-analysis/scripts/train_models_given_z.py
@@ -1,0 +1,181 @@
+"""
+2018 Gregory Way
+train_models_given_z.py
+
+This script will train various compression models given a specific z dimension.
+Each model will train several times with different initializations.
+
+The script pulls hyperparameters from a parameter file that was determined
+after initial hyperparameter sweeps testing latent dimensionality.
+
+Output:
+
+The script will save associated weights and z matrices for each permutation as
+well as reconstruction costs for all algorithms and training histories for
+Tybalt and ADAGE models. The population of models (ensemble) will be used,
+across dimensions z, for follow-up evaluations
+
+Usage:
+
+    python run_model_with_input_dimensions.py
+
+    With required command line arguments:
+
+        --num_components    The z dimensionality we're testing
+        --param_config      A tsv file (param by z dimension) indicating the
+                            specific parameter combination for the z dimension
+        --out_dir           The directory to store the output files
+
+    And optional command line arguments
+
+        --num_seeds         The number of specific models to generate
+                                default: 5
+"""
+
+import os
+import argparse
+import numpy as np
+import pandas as pd
+from tybalt.data_models import DataModel
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-n', '--num_components', help='dimensionality of z')
+parser.add_argument('-p', '--param_config',
+                    help='text file optimal hyperparameter assignment for z')
+parser.add_argument('-o', '--out_dir', help='where to save the output files')
+parser.add_argument('-s', '--num_seeds', default=5,
+                    help='number of different seeds to run on current data')
+parser.add_argument('-r', '--shuffle', action='store_true',
+                    help='randomize gene expression data for negative control')
+args = parser.parse_args()
+
+# Load command arguments
+num_components = int(args.num_components)
+param_config = args.param_config
+out_dir = args.out_dir
+num_seeds = int(args.num_seeds)
+shuffle = args.shuffle
+
+# Extract parameters from parameter configuation file
+param_df = pd.read_table(param_config, index_col=0)
+
+vae_epochs = param_df.loc['vae_epochs', str(num_components)]
+dae_epochs = param_df.loc['dae_epochs', str(num_components)]
+vae_lr = param_df.loc['vae_lr', str(num_components)]
+dae_lr = param_df.loc['dae_lr', str(num_components)]
+vae_batch_size = param_df.loc['vae_batch_size', str(num_components)]
+dae_batch_size = param_df.loc['dae_batch_size', str(num_components)]
+dae_noise = param_df.loc['dae_noise', str(num_components)]
+dae_sparsity = param_df.loc['dae_sparsity', str(num_components)]
+vae_kappa = param_df.loc['vae_kappa', str(num_components)]
+
+# Set output directory and file names
+train_dir = os.path.join(out_dir, 'training_history')
+if not os.path.exists(train_dir):
+    os.makedirs(train_dir)
+
+if shuffle:
+    file_pre = '{}_components_shuffled_'.format(num_components)
+else:
+    file_pre = '{}_components_'.format(num_components)
+
+recon_file = os.path.join(train_dir, '{}reconstruction.tsv'.format(file_pre))
+tybalt_hist_file = os.path.join(train_dir,
+                                '{}tybalt_training_hist.tsv'.format(file_pre))
+adage_hist_file = os.path.join(train_dir,
+                               '{}adage_training_hist.tsv'.format(file_pre))
+
+# Load Data
+rnaseq_file = os.path.join('data', 'pancan_scaled_zeroone_rnaseq.tsv.gz')
+rnaseq_df = pd.read_table(rnaseq_file, index_col=0)
+
+# Initialize DataModel class with pancancer data
+dm = DataModel(df=rnaseq_df)
+
+# Set seed and list of algorithms for compression
+random_seeds = np.random.randint(0, high=1000000, size=num_seeds)
+algorithms = ['pca', 'ica', 'nmf', 'adage', 'tybalt']
+
+# Save population of models in specific folder
+comp_out_dir = os.path.join(out_dir, 'components_{}'.format(num_components))
+if not os.path.exists(comp_out_dir):
+    os.makedirs(comp_out_dir)
+
+reconstruction_results = []
+tybalt_training_histories = []
+adage_training_histories = []
+for seed in random_seeds:
+    seed_file = os.path.join(comp_out_dir, 'model_{}'.format(seed))
+
+    if shuffle:
+        seed_file = '{}_shuffled'.format(seed_file)
+
+        # randomly permute genes of each sample in the rnaseq matrix
+        shuf_df = rnaseq_df.apply(lambda x: np.random.permutation(x.tolist()),
+                                  axis=1)
+
+        # Initiailze a new DataModel, with different shuffling each permutation
+        dm = DataModel(df=shuf_df)
+
+    # Fit models
+    dm.pca(n_components=num_components)
+    dm.ica(n_components=num_components)
+    dm.nmf(n_components=num_components)
+
+    dm.nn(n_components=num_components,
+          model='tybalt',
+          loss='binary_crossentropy',
+          epochs=int(vae_epochs),
+          batch_size=int(vae_batch_size),
+          learning_rate=float(vae_lr),
+          separate_loss=True,
+          verbose=False)
+
+    dm.nn(n_components=num_components,
+          model='adage',
+          loss='binary_crossentropy',
+          epochs=int(dae_epochs),
+          batch_size=int(dae_batch_size),
+          learning_rate=float(dae_lr),
+          noise=float(dae_noise),
+          sparsity=float(dae_sparsity),
+          verbose=False)
+
+    # Obtain z matrix (sample scores per latent space feature) for all models
+    full_z_matrix = dm.combine_models()
+
+    # Obtain weight matrices (gene by latent space feature) for all models
+    full_weight_matrix = dm.combine_weight_matrix()
+
+    # Store reconstruction costs at training end
+    full_reconstruction = dm.compile_reconstruction()
+
+    # Store training histories for neural network models
+    tybalt_train_history = dm.tybalt_fit.history_df
+    tybalt_train_history = tybalt_train_history.assign(seed=seed)
+    tybalt_train_history = tybalt_train_history.assign(shuffled=shuffle)
+    adage_train_history = dm.adage_fit.history_df
+    adage_train_history = adage_train_history.assign(seed=seed)
+    adage_train_history = adage_train_history.assign(shuffled=shuffle)
+
+    # Store z and weight matrices for each seed (the population of models)
+    full_z_file = '{}_z_matrix.tsv'.format(seed_file)
+    full_z_matrix.to_csv(full_z_file, sep='\t')
+
+    full_weight_file = '{}_weight_matrix.tsv'.format(seed_file)
+    full_weight_matrix.to_csv(full_weight_file, sep='\t')
+
+    reconstruction_results.append(full_reconstruction)
+    tybalt_training_histories.append(tybalt_train_history)
+    adage_training_histories.append(adage_train_history)
+
+# Save reconstruction and neural network training results
+reconstruction_df = pd.concat(reconstruction_results)
+reconstruction_df.index = range(0, num_seeds)
+tybalt_history_df = pd.concat(tybalt_training_histories)
+adage_history_df = pd.concat(adage_training_histories)
+
+# Output files
+reconstruction_df.to_csv(recon_file, sep='\t')
+tybalt_history_df.to_csv(tybalt_hist_file, sep='\t')
+adage_history_df.to_csv(adage_hist_file, sep='\t')

--- a/2.ensemble-z-analysis/scripts/z_sweep_jobs_submit.py
+++ b/2.ensemble-z-analysis/scripts/z_sweep_jobs_submit.py
@@ -1,0 +1,133 @@
+"""
+Gregory Way 2018
+scripts/z_sweep_jobs_submit.py
+
+This script will submit several jobs to the PMACS cluster at the University of
+Pennsylvania. Each job will train a model for a prespecified number of
+components, which corresponds to the latent space dimensionality.
+
+The script uses two configuration files: 1) parameter and 2) config files.
+
+1) The parameter file (required) is a tab separated file. The columns of the
+file indicate number of dimensions to constrain the model to learning. The
+index of the file indicate separate hyperparameters required as input to
+`train_models_given_z.py`. The parameters include:
+
+vae_epochs - number of epochs for Tybalt model
+dae_epochs - number of epochs for ADAGE model
+vae_lr - learning rate (step size) for Tybalt model
+dae_lr - learning rate (step size) for ADAGE model
+vae_batch_size - batch size for Tybalt model
+dae_batch_size - batch size for ADAGE model
+dae_noise - noise injected into ADAGE model training
+dae_sparsity - sparsity penalty regularization for ADAGE model training
+vae_kappa - warm up parameter for Tybalt model
+
+2) The tab sep config file has parameters for training on PMACS with a header:
+header = ["variable", "assign"]
+The values include:
+queue - the queue that will schedule and run jobs
+num_gpus - how many GPUs to request (if "gpu" queue requested)
+num_gpus_shared - how many of these GPUs run concurrent jobs
+walltime - how long to request for each job to run
+
+NOTE: Either a PMACS configuration file or a `--local` flag must be provided.
+
+Usage: Run in command line: python scripts/latent_space_sweep_submit.py
+
+     with required command arguments:
+
+       --components         space separated dimensionalities to submit jobs for
+                            e.g. "--num_components 2 5 10" will submit 3 jobs
+                            fitting 2, 5, and 10 latent space dimensions
+       --param_config       location of tsv file (param by z dimension) for the
+                            specific parameter combination for each z dimension
+       --out_dir            filepath of where to save the results
+
+     and optional arguments:
+
+       --pmacs_config       filepath pointing to PMACS configuration file
+       --python_path        absolute path of PMACS python in select environment
+                              default: '~/.conda/envs/tybalt-gpu/bin/python'
+       --num_seeds          how many models to build (random seeds to set)
+                              default: 5
+       --local              if provided, sweep will be run locally instead
+
+Output:
+Submit jobs given certain number of latent space dimensionality
+"""
+
+import os
+import argparse
+import pandas as pd
+from bsub_helper import bsub_help
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-n', '--components', help='dimensionality to sweep over',
+                    nargs='+')
+parser.add_argument('-y', '--param_config',
+                    help='locaiton of the parameter configuration')
+parser.add_argument('-d', '--out_dir', help='folder to store results')
+parser.add_argument('-c', '--pmacs_config', default='config/pmacs_config.tsv',
+                    help='location of the configuration file for PMACS')
+parser.add_argument('-p', '--python_path', help='absolute path of python',
+                    default='python')
+parser.add_argument('-s', '--num_seeds', default=5,
+                    help='number of different seeds to run on current data')
+parser.add_argument('-l', '--local', action='store_true',
+                    help='decision to run models locally instead of on PMACS')
+args = parser.parse_args()
+
+pmacs_config_file = args.pmacs_config
+param_config_file = args.param_config
+out_dir = args.out_dir
+python_path = args.python_path
+num_seeds = args.num_seeds
+components = args.components
+local = args.local
+
+# Required to update shell for `subprocess` module if running locally
+if local:
+    shell = False
+else:
+    shell = True
+
+if not os.path.exists(out_dir):
+    os.makedirs(out_dir)
+
+# Load data
+config_df = pd.read_table(pmacs_config_file, index_col=0)
+
+# Retrieve PMACS configuration
+queue = config_df.loc['queue']['assign']
+num_gpus = config_df.loc['num_gpus']['assign']
+num_gpus_shared = config_df.loc['num_gpus_shared']['assign']
+walltime = config_df.loc['walltime']['assign']
+
+# Set default parameter combination
+conda = ['conda', 'activate', 'tybalt-gpu']
+default_params = ['--param_config', param_config_file,
+                  '--out_dir', out_dir,
+                  '--num_seeds', num_seeds]
+
+# Build lists of job commands depending on input algorithm
+all_commands = []
+for z in components:
+    z_command = [python_path, 'train_models_given_z.py', '--num_components', z]
+    if local:
+        z_command += default_params
+    else:
+        z_command = conda + z_command + default_params
+    all_commands.append(z_command)
+
+# Submit the jobs to PMACS
+for command in all_commands:
+    print(command)
+    b = bsub_help(command=command,
+                  queue=queue,
+                  num_gpus=num_gpus,
+                  num_gpus_shared=num_gpus_shared,
+                  walltime=walltime,
+                  local=local,
+                  shell=shell)
+    b.submit_command()

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,5 @@ dependencies:
 - conda-forge::r-irkernel=0.8.11
 - pip:
   - hetio==0.2.8
+  - git+https://github.com/greenelab/tybalt@f89156f03ee20abfbe0def493746f47ffadae768
+


### PR DESCRIPTION
Continued analysis migration from `tybalt` to `interpret-compression`. This is in the same vein as #7 

Two two scripts (`2.ensemble-z-analysis/scripts/train_models_given_z.py` and `2.ensemble-z-analysis/scripts/z_sweep_jobs_submit.py`) have already been reviewed by @jaclyn-taroni and @danich1 

The updates are:

1. Adding analysis `README.md` - this is a new file
2. Adding `tybalt` as pip install to `environment.yml`