### PR TITLE
Adding GSEA analysis scripts

### DIFF
--- a/5.analyze-weights/gsea.py
+++ b/5.analyze-weights/gsea.py
@@ -1,0 +1,117 @@
+"""
+2018 Gregory Way
+5.analyze-components/gsea.py
+
+Submit jobs that perform GSEA on all compiled weight matrices
+
+Usage:
+
+    Run in command line:
+
+            python gsea.py
+
+     with optional arguments:
+       --pmacs_config       filepath pointing to PMACS configuration file
+       --python_path        absolute path of PMACS python in select environment
+                              default: '~/.conda/envs/tybalt-gpu/bin/python'
+       --local              if provided, sweep will be run locally instead
+
+Output:
+
+    Will submit jobs for each ensemble of compressed weight matrix (directory)
+"""
+
+import os
+import sys
+import argparse
+import pandas as pd
+
+sys.path.insert(0, '../scripts/util')
+from bsub_helper import bsub_help
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--pmacs_config',
+                    default='../config/pmacs_config.tsv',
+                    help='location of the configuration file for PMACS')
+parser.add_argument('-p', '--python_path', help='absolute path of python',
+                    default='python')
+parser.add_argument('-l', '--local', action='store_true',
+                    help='decision to run models locally instead of on PMACS')
+args = parser.parse_args()
+
+pmacs_config_file = args.pmacs_config
+python_path = args.python_path
+local = args.local
+
+# Load data
+config_df = pd.read_table(pmacs_config_file, index_col=0)
+
+# Retrieve PMACS configuration
+queue = config_df.loc['queue']['assign']
+num_gpus = config_df.loc['num_gpus']['assign']
+num_gpus_shared = config_df.loc['num_gpus_shared']['assign']
+walltime = config_df.loc['walltime']['assign']
+
+# Load constants to be used in downstream analysis
+algorithms = ['pca', 'ica', 'nmf', 'dae', 'vae']
+distrib_methods = ['full', 'full_squared', 'pos_neg', 'pos_neg_high_weight']
+num_perm = '20'
+
+# First step is to compile all files and directories
+base_file = os.path.join('..', '2.ensemble-z-analysis', 'results')
+datasets = ['TCGA', 'TARGET', 'GTEX']
+processing = ['results', 'shuffled_results']
+
+# Set default parameter combination
+conda = ['conda', 'activate', 'interpret-compression', '&&']
+
+# Generate a dictionary that stores the locations of the directories and other
+# pertinent information about the model of interest
+all_file_dict = {}
+for dataset in datasets:
+    all_file_dict[dataset] = {}
+    for signal in processing:
+        all_file_dict[dataset][signal] = {}
+        full_dir = os.path.join(base_file, '{}_{}'.format(dataset, signal),
+                                'ensemble_z_matrices')
+        for comp_file in os.listdir(full_dir):
+            z_dir = os.path.join(full_dir, comp_file)
+            z_dim = comp_file.split('_')[2]
+            all_file_dict[dataset][signal][z_dim] = z_dir
+
+# Now, loop through this dictionary and generate an iterable list
+all_commands = []
+for dataset in all_file_dict.keys():
+    dataset_file_dict = all_file_dict[dataset]
+    for signal in dataset_file_dict.keys():
+        signal_file_dict = dataset_file_dict[signal]
+        for z in signal_file_dict.keys():
+            input_z_weight_dir = signal_file_dict[z]
+
+            command = [python_path, 'scripts/submit_gsea.py',
+                       '--input_weight_dir', input_z_weight_dir,
+                       '--z_dim', z,
+                       '--dataset_name', dataset,
+                       '--num_perm', num_perm,
+                       '--algorithms', ' '.join(algorithms),
+                       '--distrib_methods', ' '.join(distrib_methods)]
+
+            if signal != 'results':
+                command += ['--shuffled']
+
+            if not local:
+                command = conda + command
+
+            all_commands.append(command)
+
+# Submit the jobs
+if __name__ == "__main__":
+    for command in all_commands:
+        print(command)
+        b = bsub_help(command=command,
+                      queue=queue,
+                      num_gpus=num_gpus,
+                      num_gpus_shared=num_gpus_shared,
+                      walltime=walltime,
+                      local=local)
+        b.submit_command()

--- a/5.analyze-weights/scripts/latent.py
+++ b/5.analyze-weights/scripts/latent.py
@@ -1,0 +1,493 @@
+"""
+2018 Gregory Way
+5.analyze-components/scripts/latent.py
+
+Functions to perform gene set analyses on compressed gene expression weights
+
+Usage:
+
+    import only
+
+    from scripts.latent import latentModel
+
+Output:
+
+A python class with several attributes and methods to assign biology to
+compressed gene expression features.
+"""
+
+import os
+import glob
+import gseapy as gp
+import pandas as pd
+
+
+class latentModel():
+    """
+    Methods for processing a weight matrix from a compression model
+
+    Usage:
+    from scripts.latent import latentModel
+    w = latentModel(filename)
+    """
+    def __init__(self, filename, z_dim=None, dataset_name=None,
+                 algorithm_name=None, weight_seed=None, shuffled_true=False):
+        """
+        The latent model is initialized with a filename that will load a weight
+        matrix and set appropriate attributes.
+
+        Arguments:
+        filename - will store the filename for the selected weight matrix
+        z_dim - the dimensionality of the bottleneck layer
+        algorithm_name - the name of the compression algorithm
+        weight_seed - the seed used to compile the specific weight matrix
+        shuffled_true - boolean if the data were shuffled prior to compression
+        """
+        # Load gene expression data
+        self.filename = filename
+        self.w_df = pd.read_table(self.filename, index_col=0)
+
+        # Set attributes
+        self.z_dim = z_dim
+        self.dataset_name = dataset_name.upper()
+        self.weight_seed = int(weight_seed)
+        self.shuffled_true = shuffled_true
+        self.is_gene_dictionary_loaded = False
+
+        if algorithm_name:
+            self.algorithm_name = algorithm_name.lower()
+            use_cols = self.w_df.columns.str.contains(self.algorithm_name)
+            self.w_df = self.w_df.loc[:, use_cols]
+
+    def _split_genes(self, pos_w_df, neg_w_df):
+        """
+        Internal method to process positive and negative tailed genes by some
+        prior determination
+
+        Arguments:
+        pos_w_df - a boolean matrix of genes in the positive tail
+        neg_w_df - a boolean matrix of genes in the negative tail
+
+        Output:
+        A long dataframe of positive and negative genes
+        """
+
+        rename_cols = ['entrez_gene', 'feature', 'feature_weight']
+
+        pos_w_df = pos_w_df.stack().reset_index()
+        pos_w_df.columns = rename_cols
+        pos_w_df = pos_w_df.dropna()
+
+        neg_w_df = neg_w_df.stack().reset_index()
+        neg_w_df.columns = rename_cols
+        neg_w_df = neg_w_df.dropna()
+
+        return pos_w_df, neg_w_df
+
+    def _load_gene_dict(self, hash='ad9631bb4e77e2cdc5413b0d77cb8f7e93fc5bee'):
+        """
+        Internal method to load gene dictionary from
+        https://github.com/cognoma/genes
+
+        Arguments:
+        hash - a string indicating which commit hash version to load data
+        """
+
+        url = 'https://raw.githubusercontent.com/cognoma/genes/' + \
+            '{}/data/genes.tsv'.format(hash)
+        self.gene_dictionary_df = (
+            pd.read_table(url)
+            .query("gene_type == 'protein-coding'")
+        )
+
+        self.is_gene_dictionary_loaded = True
+
+    def get_high_weight_genes(self, std_dev=2.5, long_format=False):
+        """
+        Method to obtain high weight genes for all latent space features in a
+        given weight matrix
+
+        Arguments:
+        std_dev - how many standard deviations above the mean to consider
+        long_format - boolean to output data in wide or long format
+        """
+
+        feature_mean = self.w_df.mean()
+        std_dev_cutoff = std_dev * self.w_df.std()
+
+        self.pos_high_w_df = feature_mean + std_dev_cutoff
+        self.neg_high_w_df = feature_mean - std_dev_cutoff
+
+        self.pos_high_w_df = self.w_df.ge(self.pos_high_w_df)
+        self.neg_high_w_df = self.w_df.le(self.neg_high_w_df)
+
+        if long_format:
+            self.pos_high_w_df, self.neg_high_w_df = (
+                self._split_genes(
+                    pos_w_df=self.pos_high_w_df,
+                    neg_w_df=self.neg_high_w_df
+                )
+            )
+
+        self.high_weight_std_cutoff = std_dev
+
+    def split_pos_neg_genes(self, long_format=False):
+        """
+        Method to split positive and negative weight genes into two features
+
+        Arguments:
+        long_format - boolean to output data in wide or long format
+        """
+
+        self.pos_w_df = self.w_df[self.w_df > 0]
+        self.neg_w_df = self.w_df[self.w_df < 0]
+
+        if long_format:
+            self.pos_w_df, self.neg_w_df = (
+                self._split_genes(
+                    pos_w_df=self.pos_w_df,
+                    neg_w_df=self.neg_w_df
+                )
+            )
+
+    def get_squared_distribution(self):
+        """
+        Method to process distribution of feature scores by squaring
+        """
+
+        self.sqr_w_df = self.w_df ** 2
+
+    def translate_gene_ids(self, gene_list, translate_from, translate_to,
+                           **kwargs):
+        """
+        Method to translate from entrez gene ids to other symbols of choice
+
+        Arguments:
+        gene_list - a list or pandas series of gene identifiers to translate
+        translate_from - string indicating the symbol type to translate from
+        translate_to - string indicating the symbol type to translate to
+
+        Return:
+        Outputs a translated list of gene IDs
+        """
+
+        # unpack kwargs
+        hash = kwargs.pop('hash', 'ad9631bb4e77e2cdc5413b0d77cb8f7e93fc5bee')
+
+        # The translation must be limited
+        choices = ['entrez_gene_id', 'symbol']
+        if translate_from not in choices or translate_to not in choices:
+            err_txt = "Translation for 'entrez_gene_id' and 'symbol' only"
+            raise ValueError(err_txt)
+
+        if not self.is_gene_dictionary_loaded:
+            self._load_gene_dict(hash=hash)
+
+        gene_mapper = dict(zip(self.gene_dictionary_df.loc[:, translate_from],
+                               self.gene_dictionary_df.loc[:, translate_to]))
+
+        gene_list = pd.Series(gene_list)
+        return gene_list.map(gene_mapper)
+
+    def _get_compressed_feature(self, weight_df, subset_algs, current_z):
+        """
+        Helper function to isolate the feature of interest
+
+        Arguments:
+        weight_df - a gene by compressed feature pandas DataFrame
+        subset_algs - a boolean vector indicating which columns correpond to
+                      the algorithm of focus
+        current_z - int describing which z vector to subset
+
+        Output:
+        A pandas Series of the compressed feature with a specific distribution
+        """
+
+        compressed_feature_df = (
+            weight_df
+            .loc[:, subset_algs]
+            .iloc[:, current_z]
+        )
+
+        return compressed_feature_df
+
+    def _get_gsea_results(self, use_df, algorithm, current_z, distribution,
+                          num_perm, shuffled, direction, seed):
+        """
+        Helper function to perform and process the GSEA results
+
+        Arguments:
+        use_df - a compressed feature
+        algorithm - a string indicating which algorithm is being analyzed
+        current_z - int describing which z vector to subset
+        distribution - a string indicating which distribution is being tested
+        num_perm - int specifying the number of permutations to use
+        shuffled - a boolean indicating if data is shuffled before training
+        direction - string indicating the distribution tail being considered
+        seed - the random seed used to train the model
+
+        Output:
+        A pandas DataFrame of processed results and attributes
+        """
+        results_df = (
+            self.run_gsea_prerank(
+                gene_score_df=use_df,
+                permutation_num=num_perm)
+            )
+
+        # Store various attributes for downstream analysis
+        results_df = (
+            results_df.assign(
+                distrib=distribution,
+                algorithm=algorithm,
+                current_z=current_z,
+                shuffled=shuffled,
+                direction=direction,
+                seed=seed
+                )
+            )
+
+        return results_df
+
+    def get_gsea_compressed_matrix(self, algorithms, distrib_methods,
+                                   shuffled, seed, num_perm=15):
+        """
+        Perform GSEA on all compressed features in a weight matrix across all
+        algorithms and distribution methods
+
+        Arguments:
+        lm - a latent model storing weight matrices and several attributes
+        algorithms - a list of algorithms to subset and analyze
+        distrib_methods - a list of methods to obtain compressed feature genes
+        shuffled - a boolean indicating if data is shuffled before training
+        seed - the random seed that the model is trained using
+        num_perm - int specifying the number of permutations to use
+
+        Output:
+        a gseapy res2d object with significant pathways (fdr) assigned to
+        compressed features
+        """
+
+        current_z_list = []
+        # Loop through all of the algorithms
+        for alg in algorithms:
+
+            # Determine the first subsetting logic
+            subset_algs = self.w_df.columns.str.contains(alg)
+
+            # Loop through the current z assignment
+            # take each column individually
+            for current_z in range(0, int(self.z_dim)):
+
+                # Now, loop through each of the distributions
+                for distrib in distrib_methods:
+                    print(alg, current_z, distrib, seed)
+
+                    # Full distributions do not require additional processing
+                    num_distrib = 1
+                    if distrib == 'full':
+                        use_df = self._get_compressed_feature(
+                            weight_df=self.w_df,
+                            subset_algs=subset_algs,
+                            current_z=current_z
+                        )
+                    elif distrib == 'full_squared':
+                        use_df = self._get_compressed_feature(
+                            weight_df=self.sqr_w_df,
+                            subset_algs=subset_algs,
+                            current_z=current_z
+                        )
+                    elif distrib == 'pos_neg':
+                        num_distrib = 2
+                        use_pos_df = self._get_compressed_feature(
+                            weight_df=self.pos_w_df,
+                            subset_algs=subset_algs,
+                            current_z=current_z
+                        )
+                        use_neg_df = self._get_compressed_feature(
+                            weight_df=self.neg_w_df,
+                            subset_algs=subset_algs,
+                            current_z=current_z
+                        )
+
+                    elif distrib == 'pos_neg_high_weight':
+                        num_distrib = 2
+                        use_pos_df = self._get_compressed_feature(
+                            weight_df=self.pos_high_w_df,
+                            subset_algs=subset_algs,
+                            current_z=current_z
+                        )
+                        use_neg_df = self._get_compressed_feature(
+                            weight_df=self.neg_high_w_df,
+                            subset_algs=subset_algs,
+                            current_z=current_z
+                        )
+
+                    # Perform GSEA on the single distribution
+                    if num_distrib == 1:
+                        results_df = (
+                            self._get_gsea_results(
+                                use_df=use_df,
+                                algorithm=alg,
+                                current_z=current_z,
+                                distribution=distrib,
+                                direction='both',
+                                num_perm=num_perm,
+                                shuffled=shuffled,
+                                seed=seed)
+                        )
+
+                        current_z_list += [results_df]
+                    # Or, perform GSEA on the double distributions, if exist
+                    elif num_distrib == 2:
+
+                        if len(use_pos_df.dropna()) != 0:
+                            results_df = (
+                                self._get_gsea_results(
+                                    use_df=use_df,
+                                    algorithm=alg,
+                                    current_z=current_z,
+                                    distribution=distrib,
+                                    direction='positive',
+                                    num_perm=num_perm,
+                                    shuffled=shuffled,
+                                    seed=seed)
+                            )
+
+                            current_z_list += [results_df]
+
+                        if len(use_neg_df.dropna()) != 0:
+                            results_df = (
+                                self._get_gsea_results(
+                                    use_df=use_df,
+                                    algorithm=alg,
+                                    current_z=current_z,
+                                    distribution=distrib,
+                                    direction='negative',
+                                    num_perm=num_perm,
+                                    shuffled=shuffled,
+                                    seed=seed)
+                            )
+
+                            current_z_list += [results_df]
+
+    def run_gsea_prerank(self, gene_score_df, **kwargs):
+        """
+        Method to perform ranked GSEA on an input gene list and score
+
+        Arguments:
+        gene_score_df - A two column pandas DataFrame (no column names) with
+                        the first column storing Hugo gene symbols and the
+                        second column storing the scores
+
+        Output:
+        A gseapy res2d dataframe
+        https://gseapy.readthedocs.io/en/master/run.html#gseapy.prerank
+
+        NOTE: To get list of all available genesets run:
+
+            import gseapy
+            names = gseapy.get_library_name()
+            print(names)
+        """
+
+        gene_score_df.columns = [0, 1]
+
+        # unpack kwargs
+        gene_sets = kwargs.pop('gene_sets', 'KEGG_2016')
+        processes = kwargs.pop('processes', 1)
+        permutation_num = kwargs.pop('permutation_num', 1000)
+        verbose = kwargs.pop('verbose', False)
+        outdir = kwargs.pop('outdir', None)
+        format = kwargs.pop('format', 'png')
+        no_plot = kwargs.pop('no_plot', True)
+        fdr_cutoff = kwargs.pop('fdr_cutoff', 0.05)
+
+        # Perform the GSEA prerank
+        result = gp.prerank(rnk=gene_score_df,
+                            gene_sets=gene_sets,
+                            processes=processes,
+                            permutation_num=permutation_num,
+                            outdir=outdir,
+                            format=format,
+                            no_plot=no_plot,
+                            verbose=verbose)
+
+        result = result.res2d
+        result = (
+            result.loc[:, ['fdr', 'geneset_size']]
+            .query("fdr < @fdr_cutoff")
+        )
+
+        return result
+
+
+def run_gsea_pipeline_command(input_weight_dir, z_dim, dataset_name, num_perm,
+                              shuffled_true, algorithms, distrib_methods):
+    """
+    Perform the entire pipeline to obtain all GSEA results built into a single
+    function for multiprocessing to act upon
+
+    Arguments:
+    input_z_dir - a folder storing how many dimensions are being compressed
+    z_dim - the dimensionality of the bottleneck layer
+    dataset_name - the name of the dataset
+    num_perm - int specifying the number of permutations to use
+    shuffled_true - boolean indicating if the data were shuffled
+    algorithms - a list of algorithms to analyze
+    distrib_methods - a list of methods to obtain compressed feature gene lists
+
+    Output:
+    for each input z directory, a results file will be written to disk
+    """
+
+    # Step 0 - Compile all of the weight matrices in a dictionary
+    weight_matrices = {}
+    for file_name in glob.glob('{}/*_weight_matrix*'.format(input_weight_dir)):
+        seed = file_name.split('/')[-1].split('_')[1]
+        weight_matrices[seed] = file_name
+
+    # Loop over all seeds in the directory
+    gsea_results_list = []
+    for seed in weight_matrices.keys():
+
+        # Step 1 - instatiate the latent model
+        file = weight_matrices[seed]
+        lm = latentModel(filename=file,
+                         z_dim=z_dim,
+                         dataset_name=dataset_name,
+                         algorithm_name=None,
+                         weight_seed=seed,
+                         shuffled_true=shuffled_true)
+
+        # Step 2 - load the gene dictionary that will help with translation
+        lm._load_gene_dict()
+
+        # Step 3 - Translate the indeces of the weight matrix
+        lm.w_df.index = (
+            lm.translate_gene_ids(
+                gene_list=lm.w_df.index,
+                translate_from='entrez_gene_id',
+                translate_to='symbol')
+        )
+
+        # Step 4 - Process the distriubtions that will be used for comparisons
+        lm.get_high_weight_genes()
+        lm.split_pos_neg_genes()
+        lm.get_squared_distribution()
+
+        gsea_results_df = (
+            lm.get_gsea_compressed_matrix(
+                algorithms=algorithms,
+                distrib_methods=distrib_methods,
+                num_perm=num_perm,
+                shuffled=shuffled_true,
+                seed=seed
+                )
+            )
+
+        gsea_results_list += gsea_results_df
+
+    out_file = 'gsea_results_{}_zdim_{}.tsv'.format(dataset_name, z_dim)
+    out_file = os.path.join('results', 'gsea', out_file)
+    pd.concat(gsea_results_list).to_csv(out_file, sep='\t')

--- a/5.analyze-weights/scripts/submit_gsea.py
+++ b/5.analyze-weights/scripts/submit_gsea.py
@@ -11,6 +11,7 @@ Usage:
             python scripts/submit_gsea.py
 
      with required command arguments:
+
        --input_weight_dir   directory storing ensemble weight matrices
        --z_dim              the given z dimension (bottleneck layer size)
                             (options: TCGA, GTEX or TARGET)
@@ -22,6 +23,12 @@ Usage:
        --distrib_methods    various mechanisms that aggregate gene lists from
                             compressed features. These gene lists are input to
                             GSEA
+
+    and optional command arguments:
+
+        --gene_sets         A keyword from Enrichr or a file path to .gmt file
+        --translate         if present, then the gene symbols in the weight
+                            matrices will be translated
 
 Output:
 
@@ -44,6 +51,10 @@ parser.add_argument('-s', '--shuffled', action='store_true',
 parser.add_argument('-a', '--algorithms', help='the algorithms to consider')
 parser.add_argument('-m', '--distrib_methods',
                     help='the distribution methods to perform')
+parser.add_argument('-g', '--gene_sets', default='KEGG_2016', nargs='+',
+                    help='gene sets to perform GSEA using')
+parser.add_argument('-t', '--translate', action='store_true',
+                    help='translate hugo symbol into entrez gene')
 args = parser.parse_args()
 
 # Set constants
@@ -54,6 +65,8 @@ num_perm = args.num_perm
 shuffled = args.shuffled
 algorithms = args.algorithms.split()
 distrib_methods = args.distrib_methods.split()
+gene_sets = args.gene_sets
+translate = args.translate
 
 # Perform the analysis
 if __name__ == "__main__":
@@ -64,5 +77,7 @@ if __name__ == "__main__":
         num_perm=num_perm,
         shuffled_true=shuffled,
         algorithms=algorithms,
-        distrib_methods=distrib_methods
+        distrib_methods=distrib_methods,
+        translate=translate,
+        gene_sets=gene_sets
     )

--- a/5.analyze-weights/scripts/submit_gsea.py
+++ b/5.analyze-weights/scripts/submit_gsea.py
@@ -1,0 +1,68 @@
+"""
+2018 Gregory Way
+5.analyze-components/scripts/submit_gsea.py
+
+Perform GSEA on all compiled weight matrices in the given directory
+
+Usage:
+
+    Run in command line:
+
+            python scripts/submit_gsea.py
+
+     with required command arguments:
+       --input_weight_dir   directory storing ensemble weight matrices
+       --z_dim              the given z dimension (bottleneck layer size)
+                            (options: TCGA, GTEX or TARGET)
+       --dataset_name       a string describing the name of the dataset used
+       --out_dir            filepath of where to save the results
+       --num_perm           number of GSEA permutations
+       --shuffled           boolean if the data was shuffled before fitting
+       --algorithms         the algorithms compressed data to interpret
+       --distrib_methods    various mechanisms that aggregate gene lists from
+                            compressed features. These gene lists are input to
+                            GSEA
+
+Output:
+
+    GSEA results for each z dimension in `5.analyze-weights/results/gsea`
+"""
+
+import argparse
+from latent import run_gsea_pipeline_command
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-w', '--input_weight_dir',
+                    help='location of the directory storing weight matrices')
+parser.add_argument('-z', '--z_dim',
+                    help='the bottleneck dimensionality to focus on')
+parser.add_argument('-d', '--dataset_name', help='name of the dataset',
+                    choices=['TCGA', 'TARGET', 'GTEX'])
+parser.add_argument('-n', '--num_perm', help='number of GSEA permutations')
+parser.add_argument('-s', '--shuffled', action='store_true',
+                    help='if the signal is shuffled or real data')
+parser.add_argument('-a', '--algorithms', help='the algorithms to consider')
+parser.add_argument('-m', '--distrib_methods',
+                    help='the distribution methods to perform')
+args = parser.parse_args()
+
+# Set constants
+input_weight_dir = args.input_weight_dir
+z_dim = args.z_dim
+dataset_name = args.dataset_name
+num_perm = args.num_perm
+shuffled = args.shuffled
+algorithms = args.algorithms.split()
+distrib_methods = args.distrib_methods.split()
+
+# Perform the analysis
+if __name__ == "__main__":
+    run_gsea_pipeline_command(
+        input_weight_dir=input_weight_dir,
+        z_dim=z_dim,
+        dataset_name=dataset_name,
+        num_perm=num_perm,
+        shuffled_true=shuffled,
+        algorithms=algorithms,
+        distrib_methods=distrib_methods
+    )

--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,12 @@
 name: interpret-compression
 channels:
 - conda-forge
+- bioconda
 dependencies:
 - conda-forge::python=3.6
-- conda-forge::pandas=0.22.0
+- conda-forge::pandas=0.23.4
 - conda-forge::xlrd=1.1.0
-- conda-forge::numpy=1.14.2
+- conda-forge::numpy=1.15.2
 - conda-forge::seaborn=0.8.1
 - conda-forge::jupyter=1.0.0
 - conda-forge::ipykernel=4.8.1
@@ -17,7 +18,8 @@ dependencies:
 - conda-forge::r-readxl=1.1.0
 - conda-forge::r-ggplot2=2.2.1
 - conda-forge::r-irkernel=0.8.11
+- bioconda::gseapy=0.9.5
 - pip:
   - git+https://github.com/dhimmel/hetio@9d9ef1320ee47609e3c61c9f4918531d3c1c8c96
   - git+https://github.com/greenelab/tybalt@739cfb894426b2dcedcf3ed48e3a43733a5cac2e
-  - git+https://github.com/greenelab/hetmech@3caf7791b32f0104cdfe362eab884d9f97a8cb1a
+  - git+https://github.com/greenelab/hetmech@b4aca774a2e9b41e6c448535d3b1cc2d9b3f85f4


### PR DESCRIPTION
The first analysis applied to interpreting the compression model weight matrices is a comprehensive GSEA analysis. There are three main scripts added in this PR.

The first script compiles and submits all the commands ([`5.analyze-weights/gsea.py`](https://github.com/greenelab/interpret-compression/pull/30/files#diff-45cd1724d733a5d951bce4424f8dd07b)). The second script actually submits each individual command ([`5.analyze-weights/scripts/submit_gsea.py`](https://github.com/greenelab/interpret-compression/pull/30/files#diff-fd9bd35e2a45b35f2cf22fd52b0b9520)). The third script contains a class and a series of methods to facilitate the GSEA analyses ([`5.analyze-weights/scripts/latent.py`](https://github.com/greenelab/interpret-compression/pull/30/files#diff-e79606bd1cee5bc2668ed0c3c272bfa5)). We use the [`gseapy`](https://gseapy.readthedocs.io/en/master/index.html) package for the GSEA implementation.

The analysis is performed as follows:

For every compressed feature within each compression weight matrix (for all datasets and signal (true or shuffled)) and all ensemble models across all z - perform GSEA. The GSEA uses genesets derived in #5 and #6. Also, GSEA is performed on four distinct compressed gene feature distributions:

1. the full, untransformed distribution
2. the full distribution squared
3. the full negative and positive tails separately
4. the high weight negative and high weight positive tails separately 
